### PR TITLE
Specifying version in a less restrictive way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ setuptools.setup(
     python_requires='>=3.7',
     # TODO: Update install requirements and corresponding documentation
     install_requires=[
-        "xarray==2022.3.0",
-        "numba==0.55.1",
-        "numpy==1.22.3",
+        "xarray>=0.20.2",
+        "numba>=0.55.0",
+        "numpy>=1.21.6",
+        "netcdf4>=1.5.8"
     ],
 )
 


### PR DESCRIPTION
This would fix https://github.com/dgilford/tcpyPI/issues/47 and https://github.com/dgilford/tcpyPI/issues/44
I wonder if it would be a good Idea to disable dependabot or at least not merge its PRs until good CI testing is in place.